### PR TITLE
Fixed hook action to support ACF

### DIFF
--- a/classes/Core.php
+++ b/classes/Core.php
@@ -17,7 +17,7 @@ class Core {
      */
     static function init() {
         // Respond to api endpoints.
-        add_action( 'plugins_loaded', array( __CLASS__, 'create_routes' ) );
+        add_action( 'init', array( __CLASS__, 'create_routes' ) );
     }
 
     /**


### PR DESCRIPTION
ACF doesn't work with wp-exhale when it is hooked to "plugins_loaded" action.