### PR TITLE
Fixed add() method with empty values

### DIFF
--- a/classes/Base/XML_Item.php
+++ b/classes/Base/XML_Item.php
@@ -16,7 +16,7 @@ class XML_Item {
      * Or in different parameters add($item,$value)
      */
     function add($item, $value=null) {
-        if ($value != null) {
+        if (!is_array($item)) {
             $this->data[] = [$item => $value];
         } else {
             $this->data[] = $item;


### PR DESCRIPTION
If you change the `$value != null` to `!is_array($item)` the method should retain it's old functionality but now you can also add empty values with:

```
$item->add('test', null);
```

Without having to do:

```
$item->add([
    'name' => 'test',
    'value' => null
]);
```